### PR TITLE
More coverage of common invalidators

### DIFF
--- a/src/CommonWorldInvalidations.jl
+++ b/src/CommonWorldInvalidations.jl
@@ -60,32 +60,10 @@ Base.:(==)(::Nothing, ::Despec3) = Despec4()
 Base.:(==)(::Nothing, ::Despec4) = Despec1()
 Base.:(==)(::Nothing, ::Despec1) = Despec2()
 
-#=
-Base.:(==)(::Despec1, ::Symbol) = Despec3()
-Base.:(==)(::Despec2, ::Symbol) = Despec4()
-Base.:(==)(::Despec3, ::Symbol) = Despec1()
-Base.:(==)(::Despec4, ::Symbol) = Despec2()
-
-Base.:(==)(::Any, ::Despec2) = Despec3()
-Base.:(==)(::Any, ::Despec3) = Despec4()
-Base.:(==)(::Any, ::Despec4) = Despec1()
-Base.:(==)(::Any, ::Despec1) = Despec2()
-
-Base.isequal(::Despec1, ::Despec2)::Bool = true
-Base.isequal(::Despec2, ::Despec3)::Bool = true
-Base.isequal(::Despec3, ::Despec4)::Bool = true
-Base.isequal(::Despec4, ::Despec1)::Bool = true
-
-Base.zip(a::Despec1...) = Despec2()
-Base.zip(a::Despec2...) = Despec3()
-Base.zip(a::Despec3...) = Despec4()
-Base.zip(a::Despec4...) = Despec1()
-
-Base.Symbol(a::Despec1...) = :Despec2
-Base.Symbol(a::Despec2...) = :Despec3
-Base.Symbol(a::Despec3...) = :Despec4
-Base.Symbol(a::Despec4...) = :Despec1
-=#
+Base.:(==)(::Despec1, ::Symbol) = false
+Base.:(==)(::Despec2, ::Symbol) = false
+Base.:(==)(::Despec3, ::Symbol) = false
+Base.:(==)(::Despec4, ::Symbol) = false
 
 struct UDespec1 <: AbstractUnitRange{Float64} end
 struct UDespec2 <: AbstractUnitRange{Float64} end
@@ -125,14 +103,6 @@ Base.eachindex(::Base.IndexLinear, ::VDespec1) = VDespec2()
 Base.eachindex(::Base.IndexLinear, ::VDespec2) = VDespec3()
 Base.eachindex(::Base.IndexLinear, ::VDespec3) = VDespec4()
 Base.eachindex(::Base.IndexLinear, ::VDespec4) = VDespec1()
-
-#=
-# _any(f, A::SparseArrays.AbstractSparseMatrixCSC, ::Colon) @ SparseArrays
-Base._any(f, ::VDespec1, ::Colon)::Bool = true
-Base._any(f, ::VDespec2, ::Colon)::Bool = true
-Base._any(f, ::VDespec3, ::Colon)::Bool = true
-Base._any(f, ::VDespec4, ::Colon)::Bool = true
-=#
 
 Base.convert(::Type{T}, ::Despec1) where T<:Real = one(T)
 Base.convert(::Type{T}, ::Despec2) where T<:Real = one(T)

--- a/src/CommonWorldInvalidations.jl
+++ b/src/CommonWorldInvalidations.jl
@@ -1,15 +1,51 @@
 module CommonWorldInvalidations
 
-struct Despec1 end
-struct Despec2 end
-struct Despec3 end
-struct Despec4 end
+struct Despec1 <: Real end
+struct Despec2 <: Real end
+struct Despec3 <: Real end
+struct Despec4 <: Real end
+
+struct IDespec1 <: Integer end
+struct IDespec2 <: Integer end
+struct IDespec3 <: Integer end
+struct IDespec4 <: Integer end
 
 # Unary Operators
-!(::Despec1) = Despec2()
-!(::Despec2) = Despec3()
-!(::Despec3) = Despec4()
-!(::Despec4) = Despec1()
+for op in [:(!), :to_index]
+    @eval Base.$op(::Despec1) = Despec2()
+    @eval Base.$op(::Despec2) = Despec3()
+    @eval Base.$op(::Despec3) = Despec4()
+    @eval Base.$op(::Despec4) = Despec1()
+end
+
+# Unary Operators on Type
+for op in [:zero, :one, :to_index, :oneto]
+    @eval Base.$op(::Type{Despec1}) = Despec2()
+    @eval Base.$op(::Type{Despec2}) = Despec3()
+    @eval Base.$op(::Type{Despec3}) = Despec4()
+    @eval Base.$op(::Type{Despec4}) = Despec1()
+end
+
+# Unary Operators on Int
+for op in [:OneTo]
+    @eval Base.$op(::IDespec1) = IDespec2()
+    @eval Base.$op(::IDespec2) = IDespec3()
+    @eval Base.$op(::IDespec3) = IDespec4()
+    @eval Base.$op(::IDespec4) = IDespec1()
+end
+
+# Unary Operators on Int Type
+for op in []
+    @eval Base.$op(::Type{IDespec1}) = IDespec2()
+    @eval Base.$op(::Type{IDespec2}) = IDespec3()
+    @eval Base.$op(::Type{IDespec3}) = IDespec4()
+    @eval Base.$op(::Type{IDespec4}) = IDespec1()
+end
+
+Base.ifelse(::Despec1, x, y) = Despec2()
+Base.ifelse(::Despec2, x, y) = Despec3()
+Base.ifelse(::Despec3, x, y) = Despec4()
+Base.ifelse(::Despec4, x, y) = Despec1()
 
 # Binary Operators
 for op in [:&, :xor, :|, :(==), :!=, :>=, :<=, :<, :>, :<<, :>>, :>>>]
@@ -18,5 +54,94 @@ for op in [:&, :xor, :|, :(==), :!=, :>=, :<=, :<, :>, :<<, :>>, :>>>]
     @eval Base.$op(::Despec3, ::Despec4) = Despec1()
     @eval Base.$op(::Despec4, ::Despec1) = Despec2()
 end
+
+Base.:(==)(::Nothing, ::Despec2) = Despec3()
+Base.:(==)(::Nothing, ::Despec3) = Despec4()
+Base.:(==)(::Nothing, ::Despec4) = Despec1()
+Base.:(==)(::Nothing, ::Despec1) = Despec2()
+
+#=
+Base.:(==)(::Despec1, ::Symbol) = Despec3()
+Base.:(==)(::Despec2, ::Symbol) = Despec4()
+Base.:(==)(::Despec3, ::Symbol) = Despec1()
+Base.:(==)(::Despec4, ::Symbol) = Despec2()
+
+Base.:(==)(::Any, ::Despec2) = Despec3()
+Base.:(==)(::Any, ::Despec3) = Despec4()
+Base.:(==)(::Any, ::Despec4) = Despec1()
+Base.:(==)(::Any, ::Despec1) = Despec2()
+
+Base.isequal(::Despec1, ::Despec2)::Bool = true
+Base.isequal(::Despec2, ::Despec3)::Bool = true
+Base.isequal(::Despec3, ::Despec4)::Bool = true
+Base.isequal(::Despec4, ::Despec1)::Bool = true
+
+Base.zip(a::Despec1...) = Despec2()
+Base.zip(a::Despec2...) = Despec3()
+Base.zip(a::Despec3...) = Despec4()
+Base.zip(a::Despec4...) = Despec1()
+
+Base.Symbol(a::Despec1...) = :Despec2
+Base.Symbol(a::Despec2...) = :Despec3
+Base.Symbol(a::Despec3...) = :Despec4
+Base.Symbol(a::Despec4...) = :Despec1
+
+Base.Broadcast.axistype(::Any, ::Despec2) = Despec3()
+Base.Broadcast.axistype(::Any, ::Despec3) = Despec4()
+Base.Broadcast.axistype(::Any, ::Despec4) = Despec1()
+Base.Broadcast.axistype(::Any, ::Despec1) = Despec2()
+=#
+
+struct UDespec1 <: AbstractUnitRange{Float64} end
+struct UDespec2 <: AbstractUnitRange{Float64} end
+struct UDespec3 <: AbstractUnitRange{Float64} end
+struct UDespec4 <: AbstractUnitRange{Float64} end
+
+Base.getproperty(::UDespec1, s::Symbol) = UDespec2()
+Base.getproperty(::UDespec2, s::Symbol) = UDespec3()
+Base.getproperty(::UDespec3, s::Symbol) = UDespec4()
+Base.getproperty(::UDespec4, s::Symbol) = UDespec1()
+
+struct ORDespec1 <: OrdinalRange{Int, Int} end
+struct ORDespec2 <: OrdinalRange{Int, Int} end
+struct ORDespec3 <: OrdinalRange{Int, Int} end
+struct ORDespec4 <: OrdinalRange{Int, Int} end
+Base.step(::ORDespec1) = ORDespec2()
+Base.step(::ORDespec2) = ORDespec3()
+Base.step(::ORDespec3) = ORDespec4()
+Base.step(::ORDespec4) = ORDespec1()
+
+struct VDespec1 <: AbstractVector{UInt8} end
+struct VDespec2 <: AbstractVector{UInt8} end
+struct VDespec3 <: AbstractVector{UInt8} end
+struct VDespec4 <: AbstractVector{UInt8} end
+
+Base.eachindex(::VDespec1) = VDespec2()
+Base.eachindex(::VDespec2) = VDespec3()
+Base.eachindex(::VDespec3) = VDespec4()
+Base.eachindex(::VDespec4) = VDespec1()
+
+Base.eachindex(::Base.IndexLinear, ::VDespec1) = VDespec2()
+Base.eachindex(::Base.IndexLinear, ::VDespec2) = VDespec3()
+Base.eachindex(::Base.IndexLinear, ::VDespec3) = VDespec4()
+Base.eachindex(::Base.IndexLinear, ::VDespec4) = VDespec1()
+
+#=
+# _any(f, A::SparseArrays.AbstractSparseMatrixCSC, ::Colon) @ SparseArrays
+Base._any(f, ::VDespec1, ::Colon)::Bool = true
+Base._any(f, ::VDespec2, ::Colon)::Bool = true
+Base._any(f, ::VDespec3, ::Colon)::Bool = true
+Base._any(f, ::VDespec4, ::Colon)::Bool = true
+=#
+
+struct NDespec1 <: Number end
+struct NDespec2 <: Number end
+struct NDespec3 <: Number end
+struct NDespec4 <: Number end
+
+Base.convert(::Type{T}, ::Union{NDespec1, NDespec2}) where T<:Number = NDespec1()
+Base.convert(::Type{T}, ::NDespec2) where T<:Number = NDespec2()
+Base.convert(::Type{T}, ::NDespec3) where T<:Number = NDespec3()
+Base.convert(::Type{T}, ::NDespec4) where T<:Number = NDespec4()
 
 end

--- a/src/CommonWorldInvalidations.jl
+++ b/src/CommonWorldInvalidations.jl
@@ -85,11 +85,6 @@ Base.Symbol(a::Despec1...) = :Despec2
 Base.Symbol(a::Despec2...) = :Despec3
 Base.Symbol(a::Despec3...) = :Despec4
 Base.Symbol(a::Despec4...) = :Despec1
-
-Base.Broadcast.axistype(::Any, ::Despec2) = Despec3()
-Base.Broadcast.axistype(::Any, ::Despec3) = Despec4()
-Base.Broadcast.axistype(::Any, ::Despec4) = Despec1()
-Base.Broadcast.axistype(::Any, ::Despec1) = Despec2()
 =#
 
 struct UDespec1 <: AbstractUnitRange{Float64} end
@@ -101,6 +96,11 @@ Base.getproperty(::UDespec1, s::Symbol) = UDespec2()
 Base.getproperty(::UDespec2, s::Symbol) = UDespec3()
 Base.getproperty(::UDespec3, s::Symbol) = UDespec4()
 Base.getproperty(::UDespec4, s::Symbol) = UDespec1()
+
+Base.Broadcast.axistype(::Any, ::UDespec2) = Despec3()
+Base.Broadcast.axistype(::Any, ::UDespec3) = Despec4()
+Base.Broadcast.axistype(::Any, ::UDespec4) = Despec1()
+Base.Broadcast.axistype(::Any, ::UDespec1) = Despec2()
 
 struct ORDespec1 <: OrdinalRange{Int, Int} end
 struct ORDespec2 <: OrdinalRange{Int, Int} end

--- a/src/CommonWorldInvalidations.jl
+++ b/src/CommonWorldInvalidations.jl
@@ -134,14 +134,8 @@ Base._any(f, ::VDespec3, ::Colon)::Bool = true
 Base._any(f, ::VDespec4, ::Colon)::Bool = true
 =#
 
-struct NDespec1 <: Number end
-struct NDespec2 <: Number end
-struct NDespec3 <: Number end
-struct NDespec4 <: Number end
-
-Base.convert(::Type{T}, ::Union{NDespec1, NDespec2}) where T<:Number = NDespec1()
-Base.convert(::Type{T}, ::NDespec2) where T<:Number = NDespec2()
-Base.convert(::Type{T}, ::NDespec3) where T<:Number = NDespec3()
-Base.convert(::Type{T}, ::NDespec4) where T<:Number = NDespec4()
-
+Base.convert(::Type{T}, ::Despec1) where T<:Real = one(T)
+Base.convert(::Type{T}, ::Despec2) where T<:Real = one(T)
+Base.convert(::Type{T}, ::Despec3) where T<:Real = one(T)
+Base.convert(::Type{T}, ::Despec4) where T<:Real = one(T)
 end


### PR DESCRIPTION
Testing using scripts like:

```julia
using SnoopCompileCore
using CommonWorldInvalidations
invalidations = @snoopr begin
  using Symbolics
end
using SnoopCompile
trees = invalidation_trees(invalidations)

using SnoopCompileCore
using CommonWorldInvalidations
invalidations = @snoopr begin
    using Static, FFTW
end
using SnoopCompile
trees = invalidation_trees(invalidations)
```

On Static.jl, we're basically done:

```julia
julia> invalidations = @snoopr begin
           using Static, FFTW
       end
202-element Vector{Any}:
  MethodInstance for last(::AbstractUnitRange)
 1
  MethodInstance for getproperty(::AbstractUnitRange, ::Symbol)
  "jl_method_table_insert"
 ⋮
  MethodInstance for Base.to_index(::Number)
  "jl_method_table_insert"
  to_index(x::StaticInt) @ Static ~/.julia/dev/Static/src/Static.jl:91
  "jl_method_table_insert"

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
9-element Vector{SnoopCompile.MethodInvalidations}:
 inserting ifelse(::False, x, y) @ Static ~/.julia/dev/Static/src/Static.jl:101 invalidated:
   mt_backedges: 1: signature Tuple{typeof(ifelse), Any, Integer, Integer} triggered MethodInstance for max(::T, ::T) where T<:Integer (0 children)

 inserting getproperty(x::Union{Static.OptionallyStaticUnitRange{F, L}, Static.OptionallyStaticStepRange{F, <:Any, L}} where {F, L}, s::Symbol) @ Static ~/.julia/dev/Static/src/ranges.jl:331 invalidated:
   backedges: 1: superseding getproperty(x, f::Symbol) @ Base Base.jl:37 with MethodInstance for getproperty(::AbstractUnitRange, ::Symbol) (1 children)

 inserting zero(T::Type{<:StaticFloat64}) @ Static ~/.julia/dev/Static/src/float.jl:17 invalidated:
   backedges: 1: superseding zero(::Type{T}) where T<:Number @ Base number.jl:309 with MethodInstance for zero(::Type{T} where T<:Real) (1 children)

 inserting one(T::Type{<:StaticFloat64}) @ Static ~/.julia/dev/Static/src/float.jl:18 invalidated:
   backedges: 1: superseding one(::Type{T}) where T<:Number @ Base number.jl:347 with MethodInstance for one(::Type{T} where T<:Real) (1 children)

 inserting axistype(::Any, r::Static.OptionallyStaticUnitRange{StaticInt{1}}) @ Static ~/.julia/dev/Static/src/ranges.jl:346 invalidated:
   backedges: 1: superseding axistype(a, b) @ Base.Broadcast broadcast.jl:565 with MethodInstance for Base.Broadcast.axistype(::Base.OneTo{Int64}, ::Any) (2 children)

 inserting to_index(x::StaticInt) @ Static ~/.julia/dev/Static/src/Static.jl:91 invalidated:
   backedges: 1: superseding to_index(i) @ Base indices.jl:300 with MethodInstance for Base.to_index(::Number) (5 children)
   1 mt_cache

 inserting oneto(::StaticInt{N}) where N @ Static ~/.julia/dev/Static/src/ranges.jl:147 invalidated:
   backedges: 1: superseding oneto(r) @ Base range.jl:469 with MethodInstance for Base.oneto(::Any) (6 children)

 inserting step(::Static.OptionallyStaticStepRange{<:Any, StaticInt{S}}) where S @ Static ~/.julia/dev/Static/src/ranges.jl:169 invalidated:
   mt_backedges: 1: signature Tuple{typeof(step), OrdinalRange{Int64, Int64}} triggered MethodInstance for (::Base.IteratorsMD.var"#23#25")(::OrdinalRange{Int64, Int64}) (9 children)

 inserting convert(::Type{T}, N::Union{StaticBool{N}, StaticFloat64{N}, StaticInt{N}} where N) where T<:Number @ Static ~/.julia/dev/Static/src/Static.jl:420 invalidated:
   backedges: 1: superseding convert(::Type{T}, x::T) where T<:Number @ Base number.jl:6 with MethodInstance for convert(::Type{T}, ::Real) where T<:Real (2 children)
              2: superseding convert(::Type{T}, x::Number) where T<:Number @ Base number.jl:7 with MethodInstance for convert(::Type{Int64}, ::Real) (26 children)
              3: superseding convert(::Type{T}, x::Number) where T<:Number @ Base number.jl:7 with MethodInstance for convert(::Type{T} where T<:Real, ::Real) (26 children)
```

turns into

```julia
julia> trees = invalidation_trees(invalidations)
2-element Vector{SnoopCompile.MethodInvalidations}:
 inserting axistype(::Any, r::Static.OptionallyStaticUnitRange{StaticInt{1}}) @ Static ~/.julia/dev/Static/src/ranges.jl:346 invalidated:
   backedges: 1: superseding axistype(a, b) @ Base.Broadcast broadcast.jl:565 with MethodInstance for Base.Broadcast.axistype(::Base.OneTo{Int64}, ::Any) (2 children)

 inserting convert(::Type{T}, N::Union{StaticBool{N}, StaticFloat64{N}, StaticInt{N}} where N) where T<:Number @ Static ~/.julia/dev/Static/src/Static.jl:420 invalidated:
   backedges: 1: superseding convert(::Type{T}, x::Number) where T<:Number @ Base number.jl:7 with MethodInstance for convert(::Type{T} where T<:Real, ::Real) (2 children)
              2: superseding convert(::Type{T}, x::T) where T<:Number @ Base number.jl:6 with MethodInstance for convert(::Type{T}, ::Real) where T<:Real (26 children)
              3: superseding convert(::Type{T}, x::Number) where T<:Number @ Base number.jl:7 with MethodInstance for convert(::Type{Int64}, ::Real) (26 children)
```

Still need to figure out the anys
