### PR TITLE
Add ExplicitImports.jl tests to CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,8 @@ version = "1.1.0"
 julia = "1.9"
 
 [extras]
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["ExplicitImports", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,9 @@
 # The only test is that the package precompiles and loads!
 using CommonWorldInvalidations
+using ExplicitImports
+using Test
+
+@testset "ExplicitImports" begin
+    @test check_no_implicit_imports(CommonWorldInvalidations) === nothing
+    @test check_no_stale_explicit_imports(CommonWorldInvalidations) === nothing
+end


### PR DESCRIPTION
## Summary

- Add ExplicitImports.jl as test dependency to ensure import hygiene is maintained
- The package already follows best practices (no implicit imports or stale imports found)
- Add tests to prevent regression in import cleanliness

## Analysis Results

Running ExplicitImports analysis showed:
- ✅ No implicit imports found
- ✅ No stale explicit imports found
- ℹ️ Note: `Base.Broadcast.axistype` is accessed (non-public), but this is intentional method extension

## Files Changed

- `Project.toml`: Added ExplicitImports as test dependency
- `test/runtests.jl`: Added ExplicitImports tests

## Test Plan

- [x] Run `Pkg.test()` locally - all tests pass
- [x] ExplicitImports checks pass

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)