### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,22 +11,12 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  downgrade:
     strategy:
       matrix:
-        downgrade_mode: ['alldeps']
         julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI checks to the centralized SciML/.github reusable workflows (pinned `@v1`, `secrets: "inherit"` on every caller).

## Converted (inline -> central)
- **Downgrade.yml**: inline `julia-actions/julia-downgrade-compat` job -> `downgrade.yml@v1`. Preserves the matrix `julia-version: [1.10]` and `skip: Pkg,TOML`. (The reusable workflow runs tests without re-resolve by default, matching the old `ALLOW_RERESOLVE: false`.)
- **FormatCheck.yml** (Runic): inline `fredrikekre/runic-action@v1` -> `runic.yml@v1`. Keeps the existing `name: format-check` and `on:` triggers.
- **SpellCheck.yml** (typos): inline `crate-ci/typos` -> `spellcheck.yml@v1`. Keeps `name: Spell Check` and `on: [pull_request]`.

## Already central (unchanged)
- **Tests.yml**: already a `tests.yml@v1` caller with `secrets: "inherit"`; matrix (`version: [1, lts, pre]`, `group: [Core]`) left exactly as-is.

## Other
- **dependabot.yml**: removed the now-unneeded `crate-ci/typos` version `ignore` block (the central spellcheck workflow pins its own typos version). `github-actions` (weekly, `/`) and `julia` (daily, group all-julia-packages, dirs `/` + `/test`) blocks preserved.
- **TagBot.yml**: unchanged.

No new callers added (Tests already present; no `docs/` so no Documentation; Downgrade/Runic/SpellCheck all already existed inline). No CompatHelper.yml to delete.

## Results
- Runic: ran `Runic.main(["--inplace","."])` locally - no changes (repo was already Runic-clean).
- typos: `typos .` exits 0 - no fixes needed.
- All changed YAML validated with `yaml.safe_load`.

## Note on branch protection
The job/check names change (e.g. the format and spellcheck jobs now run via reusable-workflow callers), so any branch-protection **required status checks** referencing the old check names will need to be updated to the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)