### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -14,9 +14,8 @@ jobs:
   downgrade:
     strategy:
       matrix:
-        julia-version: ['1.10']
+        julia-version: ['lts']
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "${{ matrix.julia-version }}"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR applies the canonical SciML CI cleanup. This is not a monorepo (no `lib/` subpackages), so no TagBot subpackage matrix is needed.

- TagBot.yml: replaced the inlined `JuliaRegistries/TagBot@v1` job with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1`.
- Downgrade.yml: removed `skip: "Pkg,TOML"` (stdlibs, auto-populated centrally); changed the matrix `julia-version: ['1.10']` -> `['lts']`.

Static verification only: edited YAML parses cleanly. No instantiate/precompile/tests were run.

Ignore until reviewed by @ChrisRackauckas.