### PR TITLE
Use SciMLTesting v1.2 (folder-based run_tests)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,16 @@ version = "1.1.0"
 
 [compat]
 ExplicitImports = "1"
+SafeTestsets = "0.1"
+SciMLTesting = "1"
 Test = "1"
 julia = "1.10"
 
 [extras]
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ExplicitImports", "Pkg", "Test"]
+test = ["ExplicitImports", "SafeTestsets", "SciMLTesting", "Test"]

--- a/test/explicitimports_tests.jl
+++ b/test/explicitimports_tests.jl
@@ -1,0 +1,8 @@
+using CommonWorldInvalidations, ExplicitImports
+using Test
+
+# The only test is that the package precompiles and loads!
+@testset "ExplicitImports" begin
+    @test check_no_implicit_imports(CommonWorldInvalidations) === nothing
+    @test check_no_stale_explicit_imports(CommonWorldInvalidations) === nothing
+end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,7 +2,8 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CommonWorldInvalidations = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -11,5 +12,7 @@ CommonWorldInvalidations = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.0.1, 0.1"
+SciMLTesting = "1"
 Test = "1"
 julia = "1.10"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,20 +1,2 @@
-using Pkg
-using CommonWorldInvalidations
-using ExplicitImports
-using Test
-
-const GROUP = get(ENV, "GROUP", "All")
-
-if GROUP == "All" || GROUP == "Core"
-    # The only test is that the package precompiles and loads!
-    @testset "ExplicitImports" begin
-        @test check_no_implicit_imports(CommonWorldInvalidations) === nothing
-        @test check_no_stale_explicit_imports(CommonWorldInvalidations) === nothing
-    end
-end
-
-if GROUP == "QA"
-    Pkg.activate(joinpath(@__DIR__, "qa"))
-    Pkg.instantiate()
-    include(joinpath(@__DIR__, "qa", "qa.jl"))
-end
+using SciMLTesting
+run_tests()


### PR DESCRIPTION
Converts `test/runtests.jl` to the SciMLTesting v1.2 **folder-discovery** model. The entire `runtests.jl` becomes:

```julia
using SciMLTesting
run_tests()
```

(Supersedes the earlier `@safetestset` canonicalization on this branch — rebuilt from `main` into the folder form.)

## Layout
- **Core** = top-level `test/*.jl` — `test/explicitimports_tests.jl` (extracted self-contained from the old inline `GROUP=="Core"` testset).
- **QA** = `test/qa/` with its existing `test/qa/Project.toml` sub-env (Aqua/JET). Folder-discovery activates the sub-env automatically (and now `Pkg.develop`s the package root so QA tests PR-branch code on Julia <1.11, matching the env's `[sources]` intent).
- Groups `Core` + `QA` per `test/test_groups.toml` (unchanged).

## Dep edits
- Root `[extras]`/`[targets].test` + `[compat]`: add `SciMLTesting = "1"` and `SafeTestsets`; drop `Pkg` (the v1.2 harness owns all `Pkg` ops).
- `test/qa/Project.toml`: add `SciMLTesting` + `SafeTestsets`; drop `Pkg`.

## Verification
Static: `TOML.parsefile` every Project.toml + test_groups.toml; `Meta.parseall` runtests.jl/qa.jl/explicitimports_tests.jl. End-to-end on Julia 1.11: `GROUP=Core` (2/2 pass) and `GROUP=QA` (7 pass, 2 broken — the pre-existing `@test_broken` markers, preserved) via `Pkg.test()`. Behavior-preserving — same test set per GROUP, no assertions changed.

Ignore until reviewed by @ChrisRackauckas.
