### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CommonWorldInvalidations"
 uuid = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 


### PR DESCRIPTION
Automated patch version bump (1.1.0 -> 1.1.1) to release unreleased commits on `main` via JuliaRegistrator.