### PR TITLE
Allow SciMLTesting v2 in QA compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "1.1.1"
 
 [compat]
 SafeTestsets = "0.1"
-SciMLTesting = "1.5"
+SciMLTesting = "1.5, 2.1"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -11,6 +11,6 @@ CommonWorldInvalidations = {path = "../.."}
 [compat]
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1.5"
+SciMLTesting = "1.5, 2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
## Summary

- Expand `SciMLTesting` compat in `Project.toml` and `test/qa/Project.toml` from `1.5` to `1.5, 2.1`.
- Keep SciMLTesting 1.5 support while allowing QA to resolve SciMLTesting 2.1+.

Ignore this PR until reviewed by @ChrisRackauckas.

## Local Verification

All Julia commands were run with Julia 1.10.11, `JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depots/CommonWorldInvalidations`, `JULIA_PKG_PRECOMPILE_AUTO=0`, and `timeout 3600`.

- `git diff --check`: passed with no output.
- Runic v1.7.0 installed in `/home/crackauc/sandbox/tmp_20260708_051717_3275/.tool_envs/runic`; `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.tool_envs/runic -e 'using Runic; exit(Runic.main(["--check", "."]))'`: passed with no output. The touched files are TOML, so this checked the repository Julia files Runic targets.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using TOML; files = ["Project.toml", "test/qa/Project.toml"]; for file in files; data = TOML.parsefile(file); @assert data["compat"]["SciMLTesting"] == "1.5, 2.1"; end; println("TOML parse/assert passed for ", join(files, ", "))'`: passed; output `TOML parse/assert passed for Project.toml, test/qa/Project.toml`.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`: passed; resolver selected `SciMLTesting v2.2.0`; output included `Core/load_tests.jl | 1 pass` and `CommonWorldInvalidations tests passed`.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.instantiate(); include("test/qa/qa.jl")'`: passed; resolver selected `SciMLTesting v2.2.0`; output included `Quality Assurance | 12 pass` and `Aqua tracked findings (issue #30) | 2 broken`.
