### PR TITLE
Require SciMLTesting v2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "1.1.1"
 
 [compat]
 SafeTestsets = "0.1"
-SciMLTesting = "1.5, 2.1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -11,6 +11,6 @@ CommonWorldInvalidations = {path = "../.."}
 [compat]
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1.5, 2.1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Require SciMLTesting 2.1 in the root and QA compat entries.
- Remove SciMLTesting v1 compatibility from package-owned compat bounds.

## Validation
- `git diff --check` passed.
- `JULIA_DEPOT_PATH="$PWD/.julia_depot" JULIA_PKG_PRECOMPILE_AUTO=0 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=.runic_env -e 'using Runic; files = split(readchomp(`git ls-files -- "*.jl"`), "\\n"); argv = ["--check"]; append!(argv, files); exit(Runic.main(argv))'` passed.\n- `GROUP=Core /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'` passed.\n- `GROUP=QA /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'` passed.\n\nGenerated manifests and depots were removed before commit.