### PR TITLE
Check rendered public API docs

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -5,9 +5,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-CommonWorldInvalidations = {path = "../.."}
-
 [compat]
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -13,6 +13,7 @@ using Test
 # unavoidable non-public-access exception is ignored on the relevant check.
 run_qa(
     CommonWorldInvalidations;
+    api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (; ambiguities = false, deps_compat = false),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- enable SciMLTesting rendered public API docs coverage in QA
- remove the QA self `[sources]` path entry

This package currently has no package-owned exported or Julia `public` API, so the rendered docs check passes as a no-op and will guard future public additions.

## Validation
- `git diff --check`
- `julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'` -> Quality Assurance 13/13; existing Aqua tracked findings remain 2 broken
- `julia +1.10 --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'` -> Core/load_tests.jl 1/1, tests passed
- Runic v1.7.0 `--check src test`
