### PR TITLE
Migrate QA to SciMLTesting 2.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "1.1.1"
 
 [compat]
 SafeTestsets = "0.1"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -8,6 +8,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -14,8 +14,7 @@ using Test
 run_qa(
     CommonWorldInvalidations;
     aqua_kwargs = (; ambiguities = false, deps_compat = false),
-    jet_kwargs = (; target_defined_modules = true),
-    explicit_imports = true,
+    jet_kwargs = (; target_modules = (CommonWorldInvalidations,)),
     ei_kwargs = (; all_qualified_accesses_are_public = (; ignore = (:axistype,))),
 )
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -13,7 +13,6 @@ using Test
 # unavoidable non-public-access exception is ignored on the relevant check.
 run_qa(
     CommonWorldInvalidations;
-    api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (; ambiguities = false, deps_compat = false),
     jet_kwargs = (; target_defined_modules = true),
     explicit_imports = true,


### PR DESCRIPTION
## Summary

- Require registry SciMLTesting 2.4 in both `Project.toml` environments without changing dependency UUIDs or adding source overrides.
- Use SciMLTesting 2.4 strict defaults for rendered API docs and ExplicitImports.
- Preserve the package-specific Aqua exceptions and narrow `axistype` ExplicitImports allowlist.
- Replace JET's deprecated `target_defined_modules = true` with the equivalent public `target_modules = (CommonWorldInvalidations,)` configuration.

## Local validation

Julia `+release` resolved to Julia 1.12.5.

### Standard package tests

```sh
$HOME/.juliaup/bin/julia +release --color=no --project=. -e 'using Pkg; Pkg.test()'
```

```text
[09d9d899] SciMLTesting v2.4.0
Test Summary:      | Pass  Total  Time
Core/load_tests.jl |    1      1  0.4s
Testing CommonWorldInvalidations tests passed
```

### Strict QA and registry resolution

```sh
$HOME/.juliaup/bin/julia +release --color=no --project=test/qa -e 'using TOML; for project in ("Project.toml", "test/qa/Project.toml"); data = TOML.parsefile(project); @assert data["compat"]["SciMLTesting"] == "2.4"; @assert !haskey(get(data, "sources", Dict{String, Any}()), "SciMLTesting"); println(project, ": SciMLTesting compat 2.4, no source override"); end; entry = only(TOML.parsefile("test/qa/Manifest.toml")["deps"]["SciMLTesting"]); @assert entry["version"] == "2.4.0"; @assert haskey(entry, "git-tree-sha1"); @assert all(key -> !haskey(entry, key), ("path", "repo-url", "repo-rev")); println("test/qa/Manifest.toml: SciMLTesting ", entry["version"], ", registry tree ", entry["git-tree-sha1"]); include("test/qa/qa.jl")'
```

```text
Project.toml: SciMLTesting compat 2.4, no source override
test/qa/Project.toml: SciMLTesting compat 2.4, no source override
test/qa/Manifest.toml: SciMLTesting 2.4.0, registry tree 7f694d4107f2babd9bd918f56e69564eb7ff44b7
Test Summary:     | Pass  Total   Time
Quality Assurance |   16     16  30.7s
Test Summary:                     | Broken  Total  Time
Aqua tracked findings (issue #30) |      2      2  0.0s
```

The two broken entries are pre-existing assertions documenting the Aqua findings already tracked in issue #30; this change adds no skipped, broken, silenced, deleted, or loosened tests.

### Formatting

Runic v1.7.0 from `/home/crackauc/sandbox/tmp_20260708_051717_3275/.formatter-commonworldinvalidations`:

```sh
$HOME/.juliaup/bin/julia +release --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.formatter-commonworldinvalidations -e 'using Runic; exit(Runic.main(["--check", "--docstrings", "test/qa/qa.jl"]))'
```

Exit code 0; no formatting changes required.

Ignore until reviewed by @ChrisRackauckas.
