### PR TITLE
Enforce strict SciMLTesting 2.4 QA

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,13 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    tags: "*"
+  pull_request:
+
+jobs:
+  docs:
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: inherit

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -3,13 +3,9 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'docs/**'
   push:
     branches:
       - main
-    paths-ignore:
-      - 'docs/**'
 jobs:
   downgrade:
     strategy:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -4,13 +4,9 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'docs/**'
   push:
     branches:
       - master
-    paths-ignore:
-      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Project.toml
+++ b/Project.toml
@@ -6,15 +6,17 @@ version = "1.1.1"
 [deps]
 
 [compat]
+Aqua = "0.8"
 SafeTestsets = "0.1"
 SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["SafeTestsets", "SciMLTesting", "Test"]
+test = ["Aqua", "SafeTestsets", "SciMLTesting", "Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+CommonWorldInvalidations = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,10 @@
+using CommonWorldInvalidations
+using Documenter
+
+doctest(CommonWorldInvalidations)
+
+makedocs(
+    modules = [CommonWorldInvalidations],
+    sitename = "CommonWorldInvalidations.jl",
+    pages = ["Home" => "index.md"],
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,8 @@
+# CommonWorldInvalidations.jl
+
+`CommonWorldInvalidations.jl` provides intentionally specialized `Base` methods used to
+exercise common-world invalidations during package loading.
+
+```@docs
+CommonWorldInvalidations
+```

--- a/src/CommonWorldInvalidations.jl
+++ b/src/CommonWorldInvalidations.jl
@@ -1,3 +1,9 @@
+"""
+    CommonWorldInvalidations
+
+Defines intentionally specialized `Base` methods that exercise common-world
+invalidations while the package is loaded.
+"""
 module CommonWorldInvalidations
 
 struct Despec1 <: Real end
@@ -70,10 +76,10 @@ Base.getproperty(::UDespec2, s::Symbol) = UDespec3()
 Base.getproperty(::UDespec3, s::Symbol) = UDespec4()
 Base.getproperty(::UDespec4, s::Symbol) = UDespec1()
 
-Base.Broadcast.axistype(::Any, ::UDespec2) = Despec3()
-Base.Broadcast.axistype(::Any, ::UDespec3) = Despec4()
-Base.Broadcast.axistype(::Any, ::UDespec4) = Despec1()
-Base.Broadcast.axistype(::Any, ::UDespec1) = Despec2()
+Base.axes(::UDespec1) = UDespec2()
+Base.axes(::UDespec2) = UDespec3()
+Base.axes(::UDespec3) = UDespec4()
+Base.axes(::UDespec4) = UDespec1()
 
 struct ORDespec1 <: OrdinalRange{Int, Int} end
 struct ORDespec2 <: OrdinalRange{Int, Int} end

--- a/test/load_tests.jl
+++ b/test/load_tests.jl
@@ -1,9 +1,7 @@
 using CommonWorldInvalidations
 using Test
 
-# This package only defines methods on internal Base functions to trigger
-# common-world invalidations; the Core test is simply that it precompiles and loads.
-# The full ExplicitImports.jl and Aqua/JET suites run in the QA group (test/qa/qa.jl).
 @testset "Load" begin
     @test CommonWorldInvalidations isa Module
+    @test axes(CommonWorldInvalidations.UDespec1()) isa CommonWorldInvalidations.UDespec2
 end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CommonWorldInvalidations = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -6,6 +7,7 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1"
 SciMLTesting = "2.4"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,25 +1,5 @@
-using SciMLTesting
 using CommonWorldInvalidations
 using JET
-using Test
+using SciMLTesting
 
-# Aqua ambiguities and deps_compat disabled: genuine findings tracked in
-# https://github.com/SciML/CommonWorldInvalidations.jl/issues/30.
-#
-# ExplicitImports.jl runs all six checks (four standard + two public-API). The
-# package defines methods on internal Base functions on purpose (its whole job is to
-# trigger common-world invalidations), so `Base.Broadcast.axistype` is accessed via
-# its non-public name with no public alternative to switch to — the single
-# unavoidable non-public-access exception is ignored on the relevant check.
-run_qa(
-    CommonWorldInvalidations;
-    aqua_kwargs = (; ambiguities = false, deps_compat = false),
-    jet_kwargs = (; target_modules = (CommonWorldInvalidations,)),
-    ei_kwargs = (; all_qualified_accesses_are_public = (; ignore = (:axistype,))),
-)
-
-# Aqua findings disabled above are genuine and tracked in issue #30.
-@testset "Aqua tracked findings (issue #30)" begin
-    @test_broken false  # Aqua ambiguities: 4 found (Base.Broadcast.axistype)
-    @test_broken false  # Aqua deps_compat: Pkg extra missing compat entry
-end
+run_qa(CommonWorldInvalidations)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- Run the exact default SciMLTesting 2.4 QA suite without exceptions.
- Replace the non-public broadcast hook with a public Base extension and add its regression test.
- Add rendered documentation and remove docs-only CI path bypasses.

## Validation
- Pkg.test() on Julia 1.10 and 1.12
- Strict run_qa(CommonWorldInvalidations) on Julia 1.10 and 1.12
- Documenter doctests and rendered docs on Julia 1.10 and 1.12
- Runic and git diff --check