### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ tracers defined in JuMP, ..., there's a huge list of libraries that can trigger 
 So what can we do about this? Enter CommonWorldInvalidations.jl. CommonWorldInvalidations.jl collects the common
 invalidation paths seen throughout the Julia ecosystem, which includes `<` assuming Bool, but also
 `||`, `>`, etc. every other Boolean operator, and forces the de-specialization of this optimization
-by simply defining a few more methods. Packages can then reply on CommonWorldInvalidations.jl and use
+by simply defining a few more methods. Packages can then rely on CommonWorldInvalidations.jl and use
 `@recompile_invalidations` which forces the Julia package image builder to recompile all code
 invalidated through these changes, which then causes the world post-import to be consistent.
 


### PR DESCRIPTION
Maybe "depend" or "use" were even better words here.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
